### PR TITLE
Aggiunta di file CI e aggiunte relative informazioni nel README

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Usa Node.js LTS
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          cache: 'npm'  
+
+      - name: Installa dipendenze
+        run: npm ci
+
+      - name: Run tests con coverage
+        run: npm test -- --coverage
+
+      - name: Upload report coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage  

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Oppure esegui all'interno della repo del progetto
 npm start
 ```
 
-## Tests
+# Tests
 
 Per eseguire i test:
 
-# setup di Jest
+## setup di Jest
 
 installa Jest con
 
@@ -64,10 +64,27 @@ inizializzalo sul tuo progetto con
 npx jest --init
 ```
 
-# Esecuzione test
+## Esecuzione test
 
 Per eseguire i test automatizzati, utilizza il comando:
 
 ```bash
 npm test
 ```
+# Continuous Integration (CI)
+
+Questo progetto utilizza GitHub Actions per eseguire automaticamente i test e generare un report di code coverage. Il workflow è configurato per attivarsi nei seguenti casi:
+- Quando viene effettuato un push sul branch `main`.
+- Quando viene aperta una pull request verso il branch `main`.
+- Quando il workflow viene avviato manualmente tramite l'interfaccia di GitHub (per comodità).
+
+### Funzionalità del Workflow
+1. **Installazione delle dipendenze**: Utilizza il comando `npm ci` per installare le dipendenze del progetto.
+2. **Esecuzione dei test**: Esegue i test automatizzati con Jest e genera un report di code coverage.
+3. **Caricamento del report di coverage**: Il report di coverage viene caricato come artefatto scaricabile.
+
+### Come visualizzare il report di coverage
+1. Vai alla sezione **Actions** del repository su GitHub.
+2. Seleziona l'esecuzione del workflow desiderata.
+3. Scarica l'artefatto chiamato `coverage-report`.
+4. Apri il file `index.html` nella cartella `coverage` per visualizzare il report.


### PR DESCRIPTION
Aggiunto file di workflow per CI, permette di eseguire automaticamente i test presenti in stringUtils.test.js ogni volta che si fa un push o pull request su main, oppure è possibile eseguirli manualmente. permette inoltre di visionare il report coverage come artefatto scaricabile. Aggiornata la documentazione nel README per includere informazioni sui test e sull'integrazione continua con GitHub Actions. 